### PR TITLE
fix typo and enable parallel make for building rpm

### DIFF
--- a/morebin.spec.in
+++ b/morebin.spec.in
@@ -23,7 +23,7 @@ Prefix:         @CPACK_PACKAGING_INSTALL_PREFIX@
 
 %build
 %cmake %{?el6:-DBoost_NO_BOOST_CMAKE=ON}
-%{__make} %{?_smp_flags}
+%{__make} %{?_smp_mflags}
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
There is a misspelled macro in morebin.spec.in. Fixing this should enable parallel make with rpmbuild and therefore faster builds. 