### PR TITLE
run clang static analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,28 @@ before_install:
   - sudo apt-get install -qq libboost-program-options-dev libboost-date-time-dev
 
 before_script:
-  - cmake .
+#ALWAYS analyze a project in its "debug" configuration
+  - if [ "$CXX" == "clang++" ];
+    then
+      cmake -DCMAKE_BUILD_TYPE=Debug .;
+    else
+      cmake .;
+    fi
 
 script:
-  - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make ; fi
+#Run the clang static analyzer.
+  - if [ "$CXX" == "clang++" ];
+    then
+      if [ ${COVERITY_SCAN_BRANCH} != 1 ];
+      then
+        scan-build make;
+      fi
+    else
+      if [ ${COVERITY_SCAN_BRANCH} != 1 ];
+      then
+        make;
+      fi
+    fi
 #  - make package # doesn't work on ubuntu
 
 notifications:


### PR DESCRIPTION
Runs the [clang static analyzer](http://clang-analyzer.llvm.org/) on all travis-ci builds using the clang compiler.