### PR TITLE
Use travis-ci container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
+sudo: false
+
 language: cpp
 
 compiler:
   - gcc
   - clang
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libboost-program-options-dev libboost-date-time-dev
+addons:
+  apt:
+    packages:
+      - libboost-program-options-dev 
+      - libboost-date-time-dev
 
 before_script:
   - cmake .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
       - libboost-program-options-dev 
       - libboost-date-time-dev
 
+before_install:
+
 before_script:
   - cmake .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - libboost-program-options-dev
-      - libboost-date-time-dev
-
 language: cpp
 
 compiler:
   - gcc
   - clang
-
-before_install:
 
 before_script:
   - cmake .
@@ -34,6 +26,10 @@ env:
    - secure: "VGO+YMWnF7ya6SoSyLYdOyXbqMFsY4Al22UQ+Wewf2BpoYNrBEUXvDNtdu54KjSmjASuDp4BTF0DD8NtzcOz+LLhkdBT8GfTcInJnxY8uYWIqciIqa1DZAuhp0pLHYfLQ2PBoKgthkMGRKg7VAcBNbXsTpwfcqcxZsX3KtYXFR8="
 
 addons:
+  apt:
+    packages:
+      - libboost-program-options-dev
+      - libboost-date-time-dev
   coverity_scan:
     project:
       name: "peterfpeterson/morebin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - libboost-program-options-dev
+      - libboost-date-time-dev
+
 language: cpp
 
 compiler:
   - gcc
   - clang
-
-addons:
-  apt:
-    packages:
-      - libboost-program-options-dev 
-      - libboost-date-time-dev
 
 before_install:
 


### PR DESCRIPTION
All of your dependencies are in the apt-package-whitelist. Therefore morebin can instead use the container-based infrastructure.