### PR TITLE
upgrade clang to eliminate false positive.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 #ALWAYS analyze a project in its "debug" configuration
   - if [ "$CXX" == "clang++" ];
     then
-      scan-build cmake -DCMAKE_BUILD_TYPE=Debug .;
+      CC=clang-3.6 CXX=clang++-3.6 scan-build cmake -DCMAKE_BUILD_TYPE=Debug .;
     else
       cmake .;
     fi
@@ -19,7 +19,7 @@ script:
 #Run the clang static analyzer.
   - if [ "$CXX" == "clang++" ];
     then
-      scan-build make;
+      CC=clang-3.6 CXX=clang++-3.6 scan-build make;
     else
       make;
     fi
@@ -34,10 +34,8 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.6
     packages:
-      - clang-3.4
-      - gcc-4.8 
-      - g++-4.8 
-      - libstdc++-4.8-dev
+      - clang-3.6
       - libboost-program-options-dev
       - libboost-date-time-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 #ALWAYS analyze a project in its "debug" configuration
   - if [ "$CXX" == "clang++" ];
     then
-      CC=clang-3.6 CXX=clang++-3.6 scan-build cmake -DCMAKE_BUILD_TYPE=Debug .;
+      CC=clang-3.6 CXX=clang++-3.6 scan-build-3.6 cmake -DCMAKE_BUILD_TYPE=Debug .;
     else
       cmake .;
     fi
@@ -19,7 +19,7 @@ script:
 #Run the clang static analyzer.
   - if [ "$CXX" == "clang++" ];
     then
-      CC=clang-3.6 CXX=clang++-3.6 scan-build make;
+      CC=clang-3.6 CXX=clang++-3.6 scan-build-3.6 make;
     else
       make;
     fi


### PR DESCRIPTION
The warning from std::vector appears to be a false positive and doesn't appear in newer versions of clang. 

```
In file included from /home/travis/build/peterfpeterson/morebin/allowedtypes.cpp:4:
In file included from /home/travis/build/peterfpeterson/morebin/allowedtypes.hpp:6:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/vector:63:
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_uninitialized.h:75:19: warning: Forming reference to null pointer
                std::_Construct(std::__addressof(*__cur), *__first);
                                ^~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```