### PR TITLE
fix gmock and gtest linking on windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,3 +30,6 @@ build:
   project: C:\projects\morebin\build\morebin.sln
   parallel: true
   verbosity: normal
+
+test_script:
+ - ctest -C Release --output-on-failure

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ configuration: Release
 
 environment:
   PROJECT_BASE: "C:/projects/morebin"
-  PATH: "%PROJECT_BASE%/boost_date_time-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/boost_program_options-vc120.1.58.0.0/lib/native/address-model-64/lib;%PATH%"
+  PATH: "%PROJECT_BASE%/boost_date_time-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/boost_program_options-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/gtest/src/gtest-build/Release;%PROJECT_BASE%/gmock/src/gmock-build/Release;%PATH%"
 
 
 platform: x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,4 +32,8 @@ build:
   verbosity: normal
 
 test_script:
- - ctest -C Release --output-on-failure
+ - ps: dir ${env:PROJECT_BASE}/boost_date_time-vc120.1.58.0.0/lib/native/address-model-64/lib
+ - ps: dir ${env:PROJECT_BASE}/boost_program_options-vc120.1.58.0.0/lib/native/address-model-64/lib
+ - ps: dir ${env:PROJECT_BASE}/build/gmock/src/gmock-build/Release
+ - ps: dir ${env:PROJECT_BASE}/build/gtest/src/gtest-build/Release
+ - cmd: ctest -C Release --output-on-failure

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ configuration: Release
 
 environment:
   PROJECT_BASE: "C:/projects/morebin"
-  PATH: "%PROJECT_BASE%/boost_date_time-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/boost_program_options-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/gtest/src/gtest-build/Release;%PROJECT_BASE%/gmock/src/gmock-build/Release;%PATH%"
+  PATH: "%PROJECT_BASE%/boost_date_time-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/boost_program_options-vc120.1.58.0.0/lib/native/address-model-64/lib;%PROJECT_BASE%/build/gtest/src/gtest-build/Release;%PROJECT_BASE%/build/gmock/src/gmock-build/Release;%PATH%"
 
 
 platform: x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,18 @@ find_package(Threads REQUIRED)
 
 include(ExternalProject)
 
+if(MSVC)
+    set(GTEST_ARGS "-DBUILD_SHARED_LIBS=ON")
+else()
+    set(GTEST_ARGS "")
+endif()
+
 # Download and install GoogleTest
 ExternalProject_Add(
     gtest
     URL https://googletest.googlecode.com/files/gtest-1.7.0.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
+    CMAKE_ARGS ${GTEST_ARGS}
     # Disable install step
     INSTALL_COMMAND ""
 )
@@ -59,11 +66,18 @@ add_dependencies(libgtest gtest)
 
 # Set gtest properties
 ExternalProject_Get_Property(gtest source_dir binary_dir)
-set_target_properties(libgtest PROPERTIES
-    "IMPORTED_LOCATION" "${binary_dir}/libgtest.a"
-    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-#    "INTERFACE_INCLUDE_DIRECTORIES" "${source_dir}/include"
-)
+if(MSVC)
+    set_target_properties(libgtest PROPERTIES
+        "IMPORTED_LOCATION_DEBUG" "${binary_dir}/Debug/gtest.lib"
+		"IMPORTED_LOCATION_RELEASE" "${binary_dir}/Release/gtest.lib"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    )
+else()
+    set_target_properties(libgmock PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/libtest.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    )
+endif()
 # I couldn't make it work with INTERFACE_INCLUDE_DIRECTORIES
 include_directories("${source_dir}/include")
 
@@ -82,11 +96,18 @@ add_dependencies(libgmock gmock)
 
 # Set gmock properties
 ExternalProject_Get_Property(gmock source_dir binary_dir)
-set_target_properties(libgmock PROPERTIES
-    "IMPORTED_LOCATION" "${binary_dir}/libgmock.a"
-    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-#    "INTERFACE_INCLUDE_DIRECTORIES" "${source_dir}/include"
-)
+if(MSVC)
+    set_target_properties(libgmock PROPERTIES
+        "IMPORTED_LOCATION_DEBUG" "${binary_dir}/Debug/gmock.lib"
+		"IMPORTED_LOCATION_RELEASE" "${binary_dir}/Release/gmock.lib"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    )
+else()
+    set_target_properties(libgmock PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/libgmock.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    )
+endif()
 # I couldn't make it work with INTERFACE_INCLUDE_DIRECTORIES
 include_directories("${source_dir}/include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ if(MSVC)
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
     )
 else()
-    set_target_properties(libgmock PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/libtest.a"
+    set_target_properties(libgtest PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/libgtest.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
     )
 endif()


### PR DESCRIPTION
I was able to fix the gtest and gmock linking by pointing IMPORTED_LOCATION to the correct file. I'm also building gmock and gtest as shared libraries because MSVC gave a long list of errors when I tried combining shared and static libraries.