### PR TITLE
Quiet error message.

### DIFF
--- a/more_bin.cpp
+++ b/more_bin.cpp
@@ -288,7 +288,7 @@ int main(int argc, char** argv)
       renderer = new render::Renderer();
       renderer->setDataDescr(dataType);
     } catch (std::runtime_error &e) {
-      std::cerr << "RUNTIME ERROR:" << e.what() << "\n";
+      //std::cerr << "RUNTIME ERROR:" << e.what() << "\n";
       renderer = new prenexus::PrenexusRenderer();
       renderer->setDataDescr(dataType);
     }


### PR DESCRIPTION
If you use type `event, pulseid, oldpulseid or rtdl` it will work but print the following error message:
```
RUNTIME ERROR:Encountered unknown type "event". Allowed types are: char, uint8, uint16, uint32, uint64, int8, int16, int32, int64, float32, float64
```
This is not needed as they are valid types.

It should only print an error message [here](https://github.com/peterfpeterson/morebin/blob/master/more_bin.cpp#L312) after both have failed.

**To test:**
This shouldn't produce an error message
```
morebin -t event /SNS/TOPAZ/IPTS-10002/0/9717/preNeXus/TOPAZ_9717_neutron_event.dat
```