### PR TITLE
Simpler AllowedTypes class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,12 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${Boost_INCLUDE_DIR})
 add_executable( morebin MACOSX_BUNDLE ${SRC_FILES} )
 target_link_libraries ( morebin ${Boost_LIBRARIES} )
 
+if(APPLE)
+ set(MOREBIN_EXECUTABLE "morebin.app/Contents/MacOS/morebin")
+else()
+ set(MOREBIN_EXECUTABLE "morebin")
+endif()
+
 add_executable( runUnitTests ${TEST_FILES} ${SRC_FILES_NO_MAIN})
 target_link_libraries ( runUnitTests
                         ${Boost_LIBRARIES}
@@ -130,7 +136,7 @@ target_link_libraries ( runUnitTests
                         ${GTEST_BOTH_LIBRARIES}
                         )
 enable_testing()
-add_test(morebin_version morebin --version)
+add_test(morebin_version ${MOREBIN_EXECUTABLE} --version)
 add_test(AllowedTypes runUnitTests --gtest_filter=AllowedTypes.*)
 add_test(string_util runUnitTests --gtest_filter=string_util.*)
 

--- a/allowedtypes.cpp
+++ b/allowedtypes.cpp
@@ -29,7 +29,7 @@ bool AllowedTypes::empty() const {
 std::ostream& operator<<(std::ostream &os, const AllowedTypes & thing) {
   if (thing.empty())
     return os;
-  os << boost::algorithm::join(thing.allowed,", ");
+  os << boost::algorithm::join(thing.allowed, ", ");
   return os;
 }
 

--- a/allowedtypes.cpp
+++ b/allowedtypes.cpp
@@ -1,7 +1,9 @@
-#include <stddef.h>
-#include <algorithm>
-
 #include "allowedtypes.hpp"
+
+#include "boost/algorithm/string.hpp"
+
+#include <algorithm>
+#include <cstddef>
 
 using std::size_t;
 using std::string;
@@ -9,65 +11,25 @@ using std::vector;
 
 namespace allowed {
 
-AllowedTypes::AllowedTypes() {
-  this->allowed = new std::vector<std::string>();
-}
-
-AllowedTypes::~AllowedTypes() {
-  if (this->allowed != NULL)
-    delete this->allowed;
-  this->allowed = NULL;
-}
-
- AllowedTypes::AllowedTypes(const AllowedTypes &rhs) {
-	 this->allowed = new std::vector<std::string>();
-	 if (!rhs.allowed->empty())
-	{
-		for (vector<string>::const_iterator it = rhs.allowed->begin();
-			it != rhs.allowed->end(); ++it)
-		{
-			this->allowed->push_back(*it);
-		}
-	}
-}
-
-AllowedTypes & AllowedTypes::operator=(const AllowedTypes &rhs) {
-  if (!rhs.allowed->empty())
-  {
-    for (vector<string>::const_iterator it = rhs.allowed->begin();
-	 it != rhs.allowed->end(); ++it)
-    {
-      this->allowed->push_back(*it);
-    }
-  }
-
-  return *this;
-}
-
 void AllowedTypes::append(const std::string & name) {
   if (!name.empty())
-    this->allowed->push_back(name);
+    this->allowed.push_back(name);
 }
 
 bool AllowedTypes::has(const std::string & descr) const {
   std::vector<std::string>::const_iterator pos
-    = std::find(this->allowed->begin(), this->allowed->end(), descr);
-  return (pos != this->allowed->end());
+    = std::find(this->allowed.begin(), this->allowed.end(), descr);
+  return (pos != this->allowed.end());
 }
 
 bool AllowedTypes::empty() const {
-  return this->allowed->empty();
+  return this->allowed.empty();
 }
 
 std::ostream& operator<<(std::ostream &os, const AllowedTypes & thing) {
   if (thing.empty())
     return os;
-  size_t size = thing.allowed->size();
-  for (size_t i = 0; i < size; i++) {
-    os << thing.allowed->at(i);
-    if (i + 1 < size)
-      os << ", ";
-  }
+  os << boost::algorithm::join(thing.allowed,", ");
   return os;
 }
 

--- a/allowedtypes.hpp
+++ b/allowedtypes.hpp
@@ -10,10 +10,6 @@ namespace allowed {
 class AllowedTypes {
 
 public:
-  AllowedTypes();
-  AllowedTypes(const AllowedTypes &rhs);
-  ~AllowedTypes();
-  AllowedTypes & operator=(const AllowedTypes &rhs);
   void append(const std::string & name);
   bool has(const std::string & descr) const;
   bool empty() const;
@@ -21,7 +17,7 @@ public:
   friend std::ostream& operator<<(std::ostream &os, const AllowedTypes & thing);
 
 private:
-  std::vector<std::string> * allowed;
+  std::vector<std::string> allowed;
 };
 
 }


### PR DESCRIPTION
I recently discovered [boost::algorithms::join](http://theboostcpplibraries.com/boost.stringalgorithms) and `AllowedTypes` has a great location to demonstrate its use. This can be switched to [std::ostream_joiner](http://en.cppreference.com/w/cpp/experimental/ostream_joiner) in C++17.

The class can also be made much simpler by making `allowed` a value instead of a pointer. Lastly I fixed a unit test that is broken on OS X.