### PR TITLE
Fix tests to run on Windoze

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ environment:
   PROJECT_BASE: "C:/projects/morebin"
   BOOST_ROOT: C:\Libraries\boost_1_60_0
   BOOST_LIBRARYDIR: C:\Libraries\boost_1_60_0\lib64-msvc-14.0
+  PATH: '%BOOST_LIBRARYDIR%;%PATH%'
 
 platform: x64
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ environment:
   PROJECT_BASE: "C:/projects/morebin"
   BOOST_ROOT: C:\Libraries\boost_1_60_0
   BOOST_LIBRARYDIR: C:\Libraries\boost_1_60_0\lib64-msvc-14.0
-  PATH: '%BOOST_LIBRARYDIR%;%PATH%'
 
 platform: x64
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 
 ######################################################################
 if (WIN32)
-  add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_ALL_DYN_LINK )
+  #add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_ALL_DYN_LINK )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4" )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,9 +158,9 @@ target_link_libraries ( runUnitTests
 
 enable_testing()
 add_test(NAME morebin_version
-         COMMAND ${MOREBIN_EXECUTABLE} "--version")
+         COMMAND ${MOREBIN_EXECUTABLE} "--version" -E environment)
 set_tests_properties(morebin_version PROPERTIES LABELS "morebin")
-set_tests_properties(morebin_version PROPERTIES ENVIRONMENT "PATH=${Boost_LIBRARY_DIR}\;$ENV{PATH}" )
+set_property(TEST morebin_version PROPERTY ENVIRONMENT "PATH=${Boost_LIBRARY_DIR}\;$ENV{PATH}" )
 add_test(NAME allowed_types
          COMMAND runUnitTests "--gtest_filter=AllowedTypes.*")
 add_test(NAME string_util

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if ( NOT stdint )
 endif ( NOT stdint )
 
 # boost
+set(Boost_USE_STATIC_LIBS ON)
 find_package ( Boost REQUIRED program_options date_time )
 message ( STATUS "Boost_INCLUDE_DIR ${Boost_INCLUDE_DIR}")
 message ( STATUS "Boost_LIBRARY_DIR ${Boost_LIBRARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ enable_testing()
 add_test(NAME morebin_version
          COMMAND ${MOREBIN_EXECUTABLE} "--version")
 set_tests_properties(morebin_version PROPERTIES LABELS "morebin")
+set_tests_properties(morebin_version PROPERTIES ENVIRONMENT "PATH=${Boost_LIBRARY_DIR};$ENV{PATH}" )
 add_test(NAME allowed_types
          COMMAND runUnitTests "--gtest_filter=AllowedTypes.*")
 add_test(NAME string_util

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ enable_testing()
 add_test(NAME morebin_version
          COMMAND ${MOREBIN_EXECUTABLE} "--version")
 set_tests_properties(morebin_version PROPERTIES LABELS "morebin")
-set_tests_properties(morebin_version PROPERTIES ENVIRONMENT "PATH=${Boost_LIBRARY_DIR};$ENV{PATH}" )
+set_tests_properties(morebin_version PROPERTIES ENVIRONMENT "PATH=${Boost_LIBRARY_DIR}\;$ENV{PATH}" )
 add_test(NAME allowed_types
          COMMAND runUnitTests "--gtest_filter=AllowedTypes.*")
 add_test(NAME string_util

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,6 @@ endif()
 
 ######################################################################
 if (WIN32)
-  #add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_ALL_DYN_LINK )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4" )
 endif()
 
@@ -159,9 +158,8 @@ target_link_libraries ( runUnitTests
 
 enable_testing()
 add_test(NAME morebin_version
-         COMMAND ${MOREBIN_EXECUTABLE} "--version" -E environment)
+         COMMAND ${MOREBIN_EXECUTABLE} "--version")
 set_tests_properties(morebin_version PROPERTIES LABELS "morebin")
-set_property(TEST morebin_version PROPERTY ENVIRONMENT "PATH=${Boost_LIBRARY_DIR}\;$ENV{PATH}" )
 add_test(NAME allowed_types
          COMMAND runUnitTests "--gtest_filter=AllowedTypes.*")
 add_test(NAME string_util


### PR DESCRIPTION
The change is to basically statically link against the boost libraries since when we use dynamic linking, the `.dll`s cannot be found in the test environment and setting the `%PATH%` doesn't seem to help.  So static linking it is! 
